### PR TITLE
Feat siuba autotable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # calitp-py
 Tools for accessing and analyzing cal-itp data
+
+## Install
+
+```
+# Note that the tools to easily query the warehouse are being developed on a
+# feature branch of siuba right now.
+pip install git+https://github.com/machow/siuba.git@feat-bigquery
+
+# Install calitp package
+pip install git+https://github.com/cal-itp/calitp-py.git
+```

--- a/calitp/tests/test_tables.py
+++ b/calitp/tests/test_tables.py
@@ -1,0 +1,62 @@
+import pytest
+import uuid
+import pandas as pd
+
+from calitp.sql import get_table, write_table, get_engine
+from calitp.tables import AutoTable
+from siuba.sql import LazyTbl
+
+from contextlib import contextmanager
+from calitp.tests.helpers import CI_SCHEMA_NAME
+
+
+# TODO: copied from tests.sql, consolidate into helpers
+@contextmanager
+def as_pipeline():
+    import os
+
+    prev_user = os.environ.get("CALITP_USER")
+
+    os.environ["CALITP_USER"] = "pipeline"
+
+    try:
+        yield
+    finally:
+        if prev_user is None:
+            del os.environ["CALITP_USER"]
+        else:
+            os.environ["CALITP_USER"] = prev_user
+
+
+@pytest.fixture
+def tmp_name():
+    from sqlalchemy.exc import NoSuchTableError
+
+    # generate a random table name. ensure it does not start with a number.
+    table_name = "t_" + str(uuid.uuid4()).replace("-", "_")
+    schema_table = f"{CI_SCHEMA_NAME}.{table_name}"
+
+    yield schema_table
+
+    try:
+        tbl = get_table(schema_table)
+        tbl.drop()
+    except NoSuchTableError:
+        pass
+
+
+def test_write_table(tmp_name):
+    schema_name, table_name = tmp_name.split(".")
+
+    df = pd.DataFrame({"x": [1, 2, 3]})
+
+    with as_pipeline():
+        write_table(df, tmp_name)
+
+    tbl = AutoTable(get_engine(), lambda s: s, lambda s: True,)  # s.replace(".", "_"),
+
+    tbl._init()
+
+    tbl_tmp = getattr(tbl.zzz_test_calitp_py, table_name)()
+
+    assert isinstance(tbl_tmp, LazyTbl)

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,6 +63,7 @@ PyYAML==5.4.1
 requests==2.25.1
 requests-oauthlib==1.3.0
 rsa==4.7.2
+git+https://github.com/machow/siuba.git@feat-bigquery
 six==1.16.0
 SQLAlchemy==1.3.24
 toml==0.10.2


### PR DESCRIPTION
* Adds a basic test for the autotable functionality
* adds siuba to requirements.txt, so tests will pass
* modifies Autotable, so that rather than `<schema_name>_<table>` you use `<schema_name>.<table>`. This let's see the schemas first, then the specific tables when autocompleting.