### PR TITLE
Feat sql staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,14 @@ pip install git+https://github.com/machow/siuba.git@feat-bigquery
 # Install calitp package
 pip install git+https://github.com/cal-itp/calitp-py.git
 ```
+
+## Configure
+
+`calitp` uses the following environment variables:
+
+* `CALITP_BQ_MAX_BYTES`
+* `CALITP_BQ_LOCATION`
+* `CALITP_USER`
+* `AIRFLOW_ENV`
+* `AIRFLOW__CORE__DAGS_FOLDER`
+* `DAGS_FOLDER`

--- a/calitp/config.py
+++ b/calitp/config.py
@@ -1,6 +1,7 @@
 import os
 import warnings
 
+from contextlib import contextmanager
 from pathlib import Path
 from functools import wraps
 
@@ -104,3 +105,23 @@ def pipe_file_name(path):
         root = Path(os.environ["DAGS_FOLDER"]).parent
 
     return str(root / path)
+
+
+@contextmanager
+def pipeline_context():
+    """Temporarily set CALITP_USER to be pipeline.
+
+    This allows a user to write to tables on production and staging.
+    """
+
+    prev_user = os.environ.get("CALITP_USER")
+
+    os.environ["CALITP_USER"] = "pipeline"
+
+    try:
+        yield
+    finally:
+        if prev_user is None:
+            del os.environ["CALITP_USER"]
+        else:
+            os.environ["CALITP_USER"] = prev_user

--- a/calitp/config.py
+++ b/calitp/config.py
@@ -81,7 +81,8 @@ def require_pipeline(func_name):
 def format_table_name(name, is_staging=False, full_name=False):
     dataset, table_name = name.split(".")
     staging = "__staging" if is_staging else ""
-    test_prefix = "zzz_test_" if is_development() else ""
+    # test_prefix = "zzz_test_" if is_development() else ""
+    test_prefix = ""
 
     project_id = get_project_id() + "." if full_name else ""
     # e.g. test_gtfs_schedule__staging.agency

--- a/calitp/config.py
+++ b/calitp/config.py
@@ -5,6 +5,10 @@ from pathlib import Path
 from functools import wraps
 
 
+CALITP_BQ_MAX_BYTES = os.environ.get("CALITP_BQ_MAX_BYTES", 5_000_000_000)
+CALITP_BQ_LOCATION = os.environ.get("CALITP_BQ_LOCATION", "us-west2")
+
+
 class RequiresAdminWarning(UserWarning):
     """Represents errors where, e.g., a user tries to load a table to the warehouse."""
 
@@ -40,6 +44,9 @@ def get_bucket():
 
 
 def get_project_id():
+    if is_development():
+        return "cal-itp-data-infra-staging"
+
     return "cal-itp-data-infra"
 
 

--- a/calitp/sql.py
+++ b/calitp/sql.py
@@ -11,7 +11,6 @@ from .config import (
     format_table_name,
     get_project_id,
     require_pipeline,
-    get_project,
 )
 
 
@@ -49,7 +48,7 @@ def get_engine(max_bytes=None):
     max_bytes = CALITP_BQ_MAX_BYTES if max_bytes is None else max_bytes
 
     return create_engine(
-        f"bigquery://{get_project()}/?maximum_bytes_billed={max_bytes}"
+        f"bigquery://{get_project_id()}/?maximum_bytes_billed={max_bytes}"
         f"?location={CALITP_BQ_LOCATION}"
     )
 

--- a/calitp/sql.py
+++ b/calitp/sql.py
@@ -47,9 +47,11 @@ def visit_insert_from_select(element, compiler, **kw):
 def get_engine(max_bytes=None):
     max_bytes = CALITP_BQ_MAX_BYTES if max_bytes is None else max_bytes
 
+    # Note that we should be able to add location as a uri parameter, but
+    # it is not being picked up, so passing as a separate argument for now.
     return create_engine(
-        f"bigquery://{get_project_id()}/?maximum_bytes_billed={max_bytes}"
-        f"?location={CALITP_BQ_LOCATION}"
+        f"bigquery://{get_project_id()}/?maximum_bytes_billed={max_bytes}",
+        location=CALITP_BQ_LOCATION,
     )
 
 

--- a/calitp/sql.py
+++ b/calitp/sql.py
@@ -168,7 +168,9 @@ def sql_patch_comments(table_name, field_comments, bq_client=None):
     if bq_client is None:
         from google.cloud import bigquery
 
-        bq_client = bigquery.Client(location=CALITP_BQ_LOCATION)
+        bq_client = bigquery.Client(
+            project=get_project_id(), location=CALITP_BQ_LOCATION
+        )
 
     tbl = bq_client.get_table(table_name)
     old_schema = tbl.schema

--- a/calitp/sql.py
+++ b/calitp/sql.py
@@ -168,7 +168,7 @@ def sql_patch_comments(table_name, field_comments, bq_client=None):
     if bq_client is None:
         from google.cloud import bigquery
 
-        bq_client = bigquery.Client()
+        bq_client = bigquery.Client(location=CALITP_BQ_LOCATION)
 
     tbl = bq_client.get_table(table_name)
     old_schema = tbl.schema

--- a/calitp/sql.py
+++ b/calitp/sql.py
@@ -5,7 +5,14 @@ from sqlalchemy.sql.expression import Executable, ClauseElement
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy import create_engine, Table, MetaData, sql
 
-from .config import format_table_name, get_project_id, require_pipeline
+from .config import (
+    CALITP_BQ_MAX_BYTES,
+    CALITP_BQ_LOCATION,
+    format_table_name,
+    get_project_id,
+    require_pipeline,
+    get_project,
+)
 
 
 class CreateTableAs(Executable, ClauseElement):
@@ -38,9 +45,12 @@ def visit_insert_from_select(element, compiler, **kw):
         """
 
 
-def get_engine():
+def get_engine(max_bytes=None):
+    max_bytes = CALITP_BQ_MAX_BYTES if max_bytes is None else max_bytes
+
     return create_engine(
-        "bigquery://cal-itp-data-infra/?maximum_bytes_billed=5000000000"
+        f"bigquery://{get_project()}/?maximum_bytes_billed={max_bytes}"
+        f"?location={CALITP_BQ_LOCATION}"
     )
 
 

--- a/calitp/storage.py
+++ b/calitp/storage.py
@@ -1,13 +1,13 @@
 import gcsfs
 
-from .config import is_development, get_bucket, require_pipeline
+from .config import is_pipeline, get_bucket, require_pipeline
 
 
-def get_fs(gcs_project="cal-itp-data-infra"):
-    if is_development():
-        return gcsfs.GCSFileSystem(project=gcs_project, token="google_default")
-    else:
+def get_fs(gcs_project=""):
+    if is_pipeline():
         return gcsfs.GCSFileSystem(project=gcs_project, token="cloud")
+    else:
+        return gcsfs.GCSFileSystem(project=gcs_project, token="google_default")
 
 
 @require_pipeline("save_to_gcfs")
@@ -44,9 +44,7 @@ def save_to_gcfs(
     return full_dst_path
 
 
-def read_gcfs(
-    src_path, dst_path=None, gcs_project="cal-itp-data-infra", bucket=None, verbose=True
-):
+def read_gcfs(src_path, dst_path=None, gcs_project="", bucket=None, verbose=True):
     """
     Arguments:
         src_path: path to file being read from google cloud.

--- a/calitp/tests/conftest.py
+++ b/calitp/tests/conftest.py
@@ -1,9 +1,3 @@
 import os
-from calitp.sql import get_engine
-from calitp.tests.helpers import CI_SCHEMA_NAME
 
 os.environ["AIRFLOW_ENV"] = "development"
-
-_engine = get_engine()
-for _name in _engine.table_names(schema=f"zzz_test_{CI_SCHEMA_NAME}"):
-    _engine.execute(f"DROP TABLE {_name};")

--- a/calitp/tests/test_storage.py
+++ b/calitp/tests/test_storage.py
@@ -1,0 +1,25 @@
+import pytest
+import uuid
+
+from calitp.config import get_bucket
+from calitp.storage import get_fs
+
+
+@pytest.fixture
+def tmp_name():
+    # generate a random table name. ensure it does not start with a number.
+    yield str(uuid.uuid4())
+
+
+def test_get_fs_pipe(tmp_name):
+    bucket = get_bucket()
+    bucket_dir = f"{bucket}/calitp/{tmp_name}"
+    fname = f"{bucket_dir}/test.txt"
+
+    fs = get_fs()
+    fs.pipe(fname, "1".encode())
+
+    res = fs.listdir(bucket_dir)
+    assert len(res) == 1
+
+    fs.cat(fname) == "1"

--- a/calitp/tests/test_storage.py
+++ b/calitp/tests/test_storage.py
@@ -4,11 +4,20 @@ import uuid
 from calitp.config import get_bucket
 from calitp.storage import get_fs
 
+GCS_BUCKET = "gs://calitp-py-ci"
+
 
 @pytest.fixture
 def tmp_name():
     # generate a random table name. ensure it does not start with a number.
-    yield str(uuid.uuid4())
+    name = f"{GCS_BUCKET}/calitp-" + str(uuid.uuid4())
+    yield name
+
+    try:
+        fs = get_fs()
+        fs.rm(tmp_name, recursive=True)
+    except Exception:
+        UserWarning("GCS folder not deleted: %s" % name)
 
 
 def test_get_fs_pipe(tmp_name):

--- a/calitp/tests/test_tables.py
+++ b/calitp/tests/test_tables.py
@@ -57,6 +57,6 @@ def test_write_table(tmp_name):
 
     tbl._init()
 
-    tbl_tmp = getattr(tbl.zzz_test_calitp_py, table_name)()
+    tbl_tmp = getattr(tbl.calitp_py, table_name)()
 
     assert isinstance(tbl_tmp, LazyTbl)

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,7 @@ PyYAML==5.4.1
 requests==2.25.1
 requests-oauthlib==1.3.0
 rsa==4.7.2
-git+https://github.com/machow/siuba.git@feat-bigquery
+git+https://github.com/machow/siuba.git@stable
 six==1.16.0
 SQLAlchemy==1.3.24
 toml==0.10.2


### PR DESCRIPTION
This PR switches the calitp library to use `cal-itp-data-infra-staging` for bigquery tables when AIRFLOW_ENV is "development". It adds a simple test of storage.

(paired w/ Charlie to test it on airflow)