### PR TITLE
fix(storage): add CALITP_AUTH to detect when on the cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,11 @@ pip install git+https://github.com/cal-itp/calitp-py.git
 * `AIRFLOW_ENV`
 * `AIRFLOW__CORE__DAGS_FOLDER`
 * `DAGS_FOLDER`
+
+### Configuration helper functions
+
+| name | env variable | description |
+| ---- | ------------ | ----------- |
+| `is_development()` | `AIRFLOW_ENV` | E.g. changes project_id between staging and production. |
+| `is_pipeline()` | `CALITP_USER` | Enables writing to warehouse. E.g. functions like `write_table()`. |
+| `is_cloud()` | `CALITP_AUTH` | Toggles GCSFS authentication to "cloud" (vs "google_default"). |

--- a/calitp/__init__.py
+++ b/calitp/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 
-__version__ = "0.0.2"
+__version__ = "0.0.3"
 
 from .sql import get_table, write_table, query_sql, to_snakecase, get_engine
 from .storage import save_to_gcfs, read_gcfs

--- a/calitp/config.py
+++ b/calitp/config.py
@@ -36,6 +36,10 @@ def is_development():
     return env == "development"
 
 
+def is_cloud():
+    return os.environ.get("CALITP_AUTH") == "cloud"
+
+
 def get_bucket():
     # TODO: can probably pull some of these behaviors into a config class
     if is_development():

--- a/calitp/storage.py
+++ b/calitp/storage.py
@@ -1,10 +1,10 @@
 import gcsfs
 
-from .config import is_pipeline, get_bucket, require_pipeline
+from .config import is_cloud, get_bucket, require_pipeline
 
 
 def get_fs(gcs_project=""):
-    if is_pipeline():
+    if is_cloud():
         return gcsfs.GCSFileSystem(project=gcs_project, token="cloud")
     else:
         return gcsfs.GCSFileSystem(project=gcs_project, token="google_default")


### PR DESCRIPTION
This PR fixes an issue preventing the pipeline from doing the combination of these things:

* not cloud: run locally
* as pipeline: allow writing data to warehouses

It separates out the 3 dimensions of use: cloud, pipeline, development. It documents what each dimension allows: pipeline to write, development for storage / db locations, cloud for authentication type.