### PR TITLE
feat: optional env var for service key

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ pip install calitp
 
 * `CALITP_BQ_MAX_BYTES`
 * `CALITP_BQ_LOCATION`
+* `CALITP_SERVICE_KEY_PATH` - an optional path to a google service key file.
 * `CALITP_USER`
 * `AIRFLOW_ENV`
 * `AIRFLOW__CORE__DAGS_FOLDER`

--- a/calitp/sql.py
+++ b/calitp/sql.py
@@ -1,3 +1,4 @@
+import os
 import pandas as pd
 
 from functools import singledispatch
@@ -47,11 +48,14 @@ def visit_insert_from_select(element, compiler, **kw):
 def get_engine(max_bytes=None):
     max_bytes = CALITP_BQ_MAX_BYTES if max_bytes is None else max_bytes
 
+    cred_path = os.environ.get("CALITP_SERVICE_KEY_PATH")
+
     # Note that we should be able to add location as a uri parameter, but
     # it is not being picked up, so passing as a separate argument for now.
     return create_engine(
         f"bigquery://{get_project_id()}/?maximum_bytes_billed={max_bytes}",
         location=CALITP_BQ_LOCATION,
+        credentials_path=cred_path,
     )
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,5 @@ services:
     build: .
     ports:
       - 8999:8888
+    volumes:
+      - .:/home/jovyan/app


### PR DESCRIPTION
Adds the option to specify a path to a service key, so we can prototype jupyter hub end-to-end.