### PR TITLE
refactor(hub): remove service_key_path env variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM jupyter/datascience-notebook
 
-ENV CALITP_SERVICE_KEY_PATH=/home/jovyan/warehouse_key.json
-
 RUN pip install \
     git+https://github.com/machow/siuba.git@stable \
     calitp==0.0.10 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM jupyter/datascience-notebook
 
+RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-361.0.0-linux-x86_64.tar.gz \
+    && tar -zxvf google-cloud-sdk-361.0.0-linux-x86_64.tar.gz \
+    && ./google-cloud-sdk/install.sh
+
 RUN pip install \
     git+https://github.com/machow/siuba.git@stable \
     calitp==0.0.10 \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,4 @@ services:
       - 8999:8888
     volumes:
       - .:/home/jovyan/app
+      - $HOME/.config/gcloud:/home/jovyan/.config/gcloud


### PR DESCRIPTION
This variable is no longer used, as we are encouraging people is use a gcloud login via terminal