### PR TITLE
Updated JupyterHub requirements.txt with Tiffany's list

### DIFF
--- a/_jupyterhub/requirements.txt
+++ b/_jupyterhub/requirements.txt
@@ -9,4 +9,13 @@ jupytext==1.13.5
 jupyterlab-code-formatter==1.4.10
 siuba==1.0.0a2
 voila==0.3.0
-plotnine
+plotnine==0.8.0
+plotly==5.5.0
+folium==0.12.1.post1
+branca==0.4.2
+altair_saver==0.5.0
+vega==3.5.0
+pygeos==0.12.0
+rtree==0.9.7
+openpyxl==3.0.9
+python-dotenv==0.19.2


### PR DESCRIPTION
Adding these libraries to _jupyterhub/requirements.txt:
- plotly==5.5.0
- folium==0.12.1.post1
- branca==0.4.2
- altair_saver==0.5.0
- vega==3.5.0
- pygeos==0.12.0
- rtree==0.9.7
- openpyxl==3.0.9
- python-dotenv==0.19.2

Libraries that were already included in image:
- calitp
- geopandas
- numpy
- pandas
- altair
- matplotlib
- plotnine
- seaborn
- ipyleaflet
- ipywidgets
- fiona
- shapely


For reference: [Tiffany's list](https://github.com/cal-itp/data-analyses/blob/main/_shared_utils/setup.py#L19)