### PR TITLE
Adding Loom tutorial to deploy JupyterHub Images

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Releasing should follow this pattern:
 
 ## Develop an Image for Jupyterhub
 
+[This Loom video](https://www.loom.com/share/1d3b00afe6314fccac55c0ce9b22ec02) walks through the process of creating and deploying new JupyterHub images that is found below.
+
 In order to test new images for Jupyterhub
 
 * create a new branch starting with development (e.g. `development`, `development-hub`).


### PR DESCRIPTION
This PR will address:

Issue [#938](https://github.com/cal-itp/data-infra/issues/938) in the data-infra repo

This issue will add to the docs the video that Michael created before leaving regarding updating and releasing new jupyterhub images.

Video URL:
https://www.loom.com/share/1d3b00afe6314fccac55c0ce9b22ec02

Location to add:
~~/kubernetes/JupyterHub/updating~~
repo: calitp-py/readme