### PR TITLE
adding random protobuff function and a cli to access it

### DIFF
--- a/calitp/__init__.py
+++ b/calitp/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 
-__version__ = "0.0.11"
+__version__ = "0.0.12"
 
 from .sql import get_table, write_table, query_sql, to_snakecase, get_engine
 from .storage import save_to_gcfs, read_gcfs

--- a/calitp/__main__.py
+++ b/calitp/__main__.py
@@ -12,9 +12,21 @@ def random_protobuff(
     date=typer.Option(f"{datetime.date.today()}*", help="Date glob.",),
     format=typer.Option("protobuff", help="format to output, json or protobuff.",),
 ):
-    blob, data = get_random_protobuff(glob, bucket=bucket, date=date, format=format,)
-    print(f"downloaded {blob}:")
-    print(data)
+    blob, data, error = get_random_protobuff(
+        glob, bucket=bucket, date=date, format=format,
+    )
+    data = str(data)
+    print(f"downloaded {blob}")
+    if error:
+        print(error)
+    lines = data.split("\n")
+    if len("\n".join(lines[:20])) > 20 * 80:
+        print(data[: 20 * 80])
+        print(f"... (only showing {20*80}/{len(data)} characters)")
+        return
+    print("\n".join(lines[:20]))
+    if len(lines) > 20:
+        print(f"... (only showing 20/{len(lines)} lines)")
 
 
 @app.callback()

--- a/calitp/__main__.py
+++ b/calitp/__main__.py
@@ -1,36 +1,19 @@
 from calitp.protobuff import get_random_protobuff
 import datetime
-import sys
 import typer
 
 app = typer.Typer()
 
+
 @app.command()
 def random_protobuff(
-        glob=typer.Argument(
-            "*",
-            help="A glob matching itp_id/url_number/string.",
-        ),
-        bucket=typer.Option(
-            "gtfs-data",
-            help="GCS bucket to search.",
-        ),
-        date=typer.Option(
-            f"{datetime.date.today()}*",
-            help="Date glob.",
-        ),
-        format=typer.Option(
-            "protobuff",
-            help="format to output, json or protobuff.",
-        ),
+    glob=typer.Argument("*", help="A glob matching itp_id/url_number/string.",),
+    bucket=typer.Option("gtfs-data", help="GCS bucket to search.",),
+    date=typer.Option(f"{datetime.date.today()}*", help="Date glob.",),
+    format=typer.Option("protobuff", help="format to output, json or protobuff.",),
 ):
-    blob, data = get_random_protobuff(
-        glob,
-        bucket=bucket,
-        date=date,
-        format=format,
-    )
-    print(f'downloaded {blob}:')
+    blob, data = get_random_protobuff(glob, bucket=bucket, date=date, format=format,)
+    print(f"downloaded {blob}:")
     print(data)
 
 
@@ -42,5 +25,6 @@ def callback():
     full --date string is like 2022-01-01T10:42:16
     --date must be at least YYYY-MM-DD and will default to zeros after that
     """
+
 
 app()

--- a/calitp/__main__.py
+++ b/calitp/__main__.py
@@ -1,0 +1,46 @@
+from calitp.protobuff import get_random_protobuff
+import datetime
+import sys
+import typer
+
+app = typer.Typer()
+
+@app.command()
+def random_protobuff(
+        glob=typer.Argument(
+            "*",
+            help="A glob matching itp_id/url_number/string.",
+        ),
+        bucket=typer.Option(
+            "gtfs-data",
+            help="GCS bucket to search.",
+        ),
+        date=typer.Option(
+            f"{datetime.date.today()}*",
+            help="Date glob.",
+        ),
+        format=typer.Option(
+            "protobuff",
+            help="format to output, json or protobuff.",
+        ),
+):
+    blob, data = get_random_protobuff(
+        glob,
+        bucket=bucket,
+        date=date,
+        format=format,
+    )
+    print(f'downloaded {blob}:')
+    print(data)
+
+
+@app.callback()
+def callback():
+    """
+    Pull a random protobuff file from the rt archiver storage.
+    without --date defaults to midnignt this morning
+    full --date string is like 2022-01-01T10:42:16
+    --date must be at least YYYY-MM-DD and will default to zeros after that
+    """
+
+app()

--- a/calitp/protobuff.py
+++ b/calitp/protobuff.py
@@ -26,7 +26,7 @@ def get_random_protobuff(glob, bucket="gtfs-data", date="", format="protobuff"):
     fs = get_fs()
     glob = glob + "*"
     globs = fs.glob(f"gs://{bucket}/rt/{date}/{glob}")
-    blob = random.choice(globs[0])
+    blob = random.choice(globs)
 
     with fs.open(blob, "rb") as f:
         result = f.read()

--- a/calitp/protobuff.py
+++ b/calitp/protobuff.py
@@ -3,6 +3,7 @@ import datetime
 from google.protobuf import json_format
 from google.transit import gtfs_realtime_pb2
 import json
+import random
 
 
 def get_random_protobuff(glob, bucket='gtfs-data', date='', format="protobuff"):
@@ -25,13 +26,13 @@ def get_random_protobuff(glob, bucket='gtfs-data', date='', format="protobuff"):
     fs = get_fs()
     glob = glob + "*"
     globs = fs.glob(f'gs://{bucket}/rt/{date}/{glob}')
-    glob = globs[0]
+    blob = random.choice(globs[0])
 
-    with fs.open(globs[0], "rb") as f:
+    with fs.open(blob, "rb") as f:
         result = f.read()
         print(len(result))
         feed.ParseFromString(result)
 
     if format == 'json':
-        return glob, json.dumps(json_format.MessageToDict(feed), indent=2)
-    return glob, feed
+        return blob, json.dumps(json_format.MessageToDict(feed), indent=2)
+    return blob, feed

--- a/calitp/protobuff.py
+++ b/calitp/protobuff.py
@@ -6,11 +6,11 @@ import json
 import random
 
 
-def get_random_protobuff(glob, bucket='gtfs-data', date='', format="protobuff"):
-    date = date.strip('*') # ignore ending asterix
-    if len(date) < len('2022-01-01'):
+def get_random_protobuff(glob, bucket="gtfs-data", date="", format="protobuff"):
+    date = date.strip("*")  # ignore ending asterix
+    if len(date) < len("2022-01-01"):
         raise ValueError("You must at least specify YYYY-MM-DD in the date string.")
-    if len(date) > len('2022-01-01T00:00:'):
+    if len(date) > len("2022-01-01T00:00:"):
         # user is specifying full time stamp
         date = date + "*"
     else:
@@ -18,14 +18,14 @@ def get_random_protobuff(glob, bucket='gtfs-data', date='', format="protobuff"):
         # This way we are prefixing on everything up to the seconds
         today = datetime.date.today().replace(day=1)
         today = datetime.datetime.fromisoformat(today.isoformat()).isoformat()
-        default_date = str(today).rsplit(':', 1)[0] + "*"
-        date = date + default_date[len(date):]
+        default_date = str(today).rsplit(":", 1)[0] + "*"
+        date = date + default_date[len(date) :]
 
     # defines the proto schema I think
     feed = gtfs_realtime_pb2.FeedMessage()
     fs = get_fs()
     glob = glob + "*"
-    globs = fs.glob(f'gs://{bucket}/rt/{date}/{glob}')
+    globs = fs.glob(f"gs://{bucket}/rt/{date}/{glob}")
     blob = random.choice(globs[0])
 
     with fs.open(blob, "rb") as f:
@@ -33,6 +33,6 @@ def get_random_protobuff(glob, bucket='gtfs-data', date='', format="protobuff"):
         print(len(result))
         feed.ParseFromString(result)
 
-    if format == 'json':
+    if format == "json":
         return blob, json.dumps(json_format.MessageToDict(feed), indent=2)
     return blob, feed

--- a/calitp/protobuff.py
+++ b/calitp/protobuff.py
@@ -1,0 +1,37 @@
+from calitp.storage import get_fs
+import datetime
+from google.protobuf import json_format
+from google.transit import gtfs_realtime_pb2
+import json
+
+
+def get_random_protobuff(glob, bucket='gtfs-data', date='', format="protobuff"):
+    date = date.strip('*') # ignore ending asterix
+    if len(date) < len('2022-01-01'):
+        raise ValueError("You must at least specify YYYY-MM-DD in the date string.")
+    if len(date) > len('2022-01-01T00:00:'):
+        # user is specifying full time stamp
+        date = date + "*"
+    else:
+        # This ensures that a date like 2022-01-01 is like 2022-01-01T00:00*
+        # This way we are prefixing on everything up to the seconds
+        today = datetime.date.today().replace(day=1)
+        today = datetime.datetime.fromisoformat(today.isoformat()).isoformat()
+        default_date = str(today).rsplit(':', 1)[0] + "*"
+        date = date + default_date[len(date):]
+
+    # defines the proto schema I think
+    feed = gtfs_realtime_pb2.FeedMessage()
+    fs = get_fs()
+    glob = glob + "*"
+    globs = fs.glob(f'gs://{bucket}/rt/{date}/{glob}')
+    glob = globs[0]
+
+    with fs.open(globs[0], "rb") as f:
+        result = f.read()
+        print(len(result))
+        feed.ParseFromString(result)
+
+    if format == 'json':
+        return glob, json.dumps(json_format.MessageToDict(feed), indent=2)
+    return glob, feed

--- a/calitp/protobuff.py
+++ b/calitp/protobuff.py
@@ -35,6 +35,10 @@ def get_random_protobuff(glob, bucket="gtfs-data", date="", format="protobuff"):
         result = f.read()
         feed.ParseFromString(result)
 
+    if not str(feed):
+        error = "ERROR: File could not be parsed as a protobuff."
+        error += " Displaying raw file instead."
+        return blob, result.decode(encoding="utf-8"), error
     if format == "json":
-        return blob, json.dumps(json_format.MessageToDict(feed), indent=2)
-    return blob, feed
+        feed = json.dumps(json_format.MessageToDict(feed), indent=2)
+    return blob, feed, None

--- a/calitp/protobuff.py
+++ b/calitp/protobuff.py
@@ -25,12 +25,14 @@ def get_random_protobuff(glob, bucket="gtfs-data", date="", format="protobuff"):
     feed = gtfs_realtime_pb2.FeedMessage()
     fs = get_fs()
     glob = glob + "*"
-    globs = fs.glob(f"gs://{bucket}/rt/{date}/{glob}")
-    blob = random.choice(globs)
+    glob = f"gs://{bucket}/rt/{date}/{glob}"
+    blobs = fs.glob(glob)
+    if len(blobs) == 0:
+        raise Exception(f"No files were found matching glob {glob}")
+    blob = random.choice(blobs)
 
     with fs.open(blob, "rb") as f:
         result = f.read()
-        print(len(result))
         feed.ParseFromString(result)
 
     if format == "json":

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ google-crc32c==1.1.2
 google-resumable-media==1.3.0
 googleapis-common-protos==1.53.0
 grpcio==1.38.0
+gtfs-realtime-bindings==0.0.7
 identify==2.2.10
 idna==2.10
 iniconfig==1.1.1
@@ -68,6 +69,7 @@ six==1.16.0
 SQLAlchemy==1.3.24
 toml==0.10.2
 traitlets==5.0.5
+typer==0.4.0
 typing-extensions==3.10.0.0
 ujson==4.0.2
 urllib3==1.26.5

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         "pandas-gbq",
         "pybigquery",
         "google-cloud-bigquery",
+        "gtfs-realtime-bindings",
     ],
     description="",
     author="",


### PR DESCRIPTION
This is in response to https://github.com/cal-itp/data-infra/issues/1142

## Instructions

If you haven't already, clone this repo and install it locally (this can be inside a venv)

``` shell
git clone git@github.com:cal-itp/calitp-py.git
pip install -e ./calitp-py
```

Next check the `python -m calitp --help` and make sure the instructions are good. Here are some sample usages:

``` shell
# Get the file for this feed at midnight this morning
python -m calitp random-protobuff 295/0/gtfs_rt_service_alerts_url

# A wildcard can be anywhere in the feed string
python -m calitp random-protobuff 295/0/*

# This defaults to midnight on the date provided
python -m calitp random-protobuff 295/0/ --date 2022-02-23

# Search at an exact time
python -m calitp random-protobuff 295/0/ --date 2022-02-23T16:01:24


# Or at a given hour/minute
python -m calitp random-protobuff 295/0/ --date 2022-02-23T16
python -m calitp random-protobuff 295/0/ --date 2022-02-23T16:01

# print the result as a json
python -m calitp random-protobuff 295/0/ --format json
```