### PR TITLE
calitp(dependencies): added sqlalchemy-bigquery, google-github-actions pinned to v0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           python -m pip install -r requirements.txt
           python -m pip install .
 
-      - uses: google-github-actions/setup-gcloud@master
+      - uses: google-github-actions/setup-gcloud@v0
         with:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true

--- a/calitp/__init__.py
+++ b/calitp/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 
-__version__ = "0.0.12"
+__version__ = "0.0.13"
 
 from .sql import get_table, write_table, query_sql, to_snakecase, get_engine
 from .storage import save_to_gcfs, read_gcfs

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         "gcsfs",
         "pandas",
         "pandas-gbq",
-        "pybigquery",
+        "sqlalchemy-bigquery",
         "google-cloud-bigquery",
         "gtfs-realtime-bindings",
     ],


### PR DESCRIPTION
This PR addresses dependency issues in calitp

Files Edited:
`.github/workflows/ci.yml`
* pinned the version of google-github-actions to v0 per their recommendation with the change from master to main

`setup.py`
* substituted `sqlalchemy-bigquery` for `pybigquery` which was causing dependency issues

`__init__.py`
* bumped up version number for new release