### PR TITLE
calitp(pre-commit): google-github-actions pinned to v0, bumped up black formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           python -m pip install -r requirements.txt
           python -m pip install .
 
-      - uses: google-github-actions/setup-gcloud@master
+      - uses: google-github-actions/setup-gcloud@v0
         with:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         args: ["--unsafe"]
       - id: check-added-large-files
   - repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/bandit


### PR DESCRIPTION
This PR addresses dependency issues in calitp-py

`.github/workflows/ci.yml`
* pinned the version of `google-github-actions` to `v0` per their recommendation due to the change from master to main
* This need was flagged in [this GH issue](https://github.com/google-github-actions/setup-gcloud/issues/539)

`.pre-commit-config.yml`
* bumped up version of `black` known to cause dependency issues to `22.3.0`
* Flagged in this [Slack thread](https://cal-itp.slack.com/archives/C02KH3DGZL7/p1648586172862549)