### PR TITLE
calitp(dependencies): added sqlalchemy-bigquery to calitp-py, removed pybigquery

### DIFF
--- a/calitp/__init__.py
+++ b/calitp/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 
-__version__ = "0.0.13"
+__version__ = "0.0.15"
 
 from .sql import get_table, write_table, query_sql, to_snakecase, get_engine
 from .storage import save_to_gcfs, read_gcfs

--- a/calitp/__init__.py
+++ b/calitp/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 
-__version__ = "0.0.12"
+__version__ = "0.0.13"
 
 from .sql import get_table, write_table, query_sql, to_snakecase, get_engine
 from .storage import save_to_gcfs, read_gcfs

--- a/calitp/__init__.py
+++ b/calitp/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 
-__version__ = "0.0.15"
+__version__ = "0.0.13"
 
 from .sql import get_table, write_table, query_sql, to_snakecase, get_engine
 from .storage import save_to_gcfs, read_gcfs

--- a/calitp/__main__.py
+++ b/calitp/__main__.py
@@ -7,13 +7,28 @@ app = typer.Typer()
 
 @app.command()
 def random_protobuff(
-    glob=typer.Argument("*", help="A glob matching itp_id/url_number/string.",),
-    bucket=typer.Option("gtfs-data", help="GCS bucket to search.",),
-    date=typer.Option(f"{datetime.date.today()}*", help="Date glob.",),
-    format=typer.Option("protobuff", help="format to output, json or protobuff.",),
+    glob=typer.Argument(
+        "*",
+        help="A glob matching itp_id/url_number/string.",
+    ),
+    bucket=typer.Option(
+        "gtfs-data",
+        help="GCS bucket to search.",
+    ),
+    date=typer.Option(
+        f"{datetime.date.today()}*",
+        help="Date glob.",
+    ),
+    format=typer.Option(
+        "protobuff",
+        help="format to output, json or protobuff.",
+    ),
 ):
     blob, data, error = get_random_protobuff(
-        glob, bucket=bucket, date=date, format=format,
+        glob,
+        bucket=bucket,
+        date=date,
+        format=format,
     )
     data = str(data)
     print(f"downloaded {blob}")

--- a/calitp/config.py
+++ b/calitp/config.py
@@ -96,9 +96,7 @@ def format_table_name(name, is_staging=False, full_name=False):
 
 
 def pipe_file_name(path):
-    """Returns absolute path for a file in the pipeline (e.g. the data folder).
-
-    """
+    """Returns absolute path for a file in the pipeline (e.g. the data folder)."""
 
     # For now, we just get the path relative to the directory holding the
     # DAGs folder. For some reason, gcp doesn't expose the same variable

--- a/calitp/tests/test_tables.py
+++ b/calitp/tests/test_tables.py
@@ -58,7 +58,11 @@ def test_write_table(tmp_name):
     with as_pipeline():
         write_table(df, tmp_name)
 
-    tbl = AutoTable(get_engine(), lambda s: s, lambda s: True,)  # s.replace(".", "_"),
+    tbl = AutoTable(
+        get_engine(),
+        lambda s: s,
+        lambda s: True,
+    )  # s.replace(".", "_"),
 
     tbl._init()
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,7 +22,7 @@ gcsfs==0.8.0
 google-api-core==2.7.1
 google-auth==1.31.0
 google-auth-oauthlib==0.4.4
-google-cloud-bigquery==3.0.1
+google-cloud-bigquery==2.25.2
 google-cloud-bigquery-storage==2.8.0
 google-cloud-core==2.2.3
 google-crc32c==1.1.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,7 +19,7 @@ filelock==3.0.12
 fsspec==2021.6.0
 future==0.18.2
 gcsfs==0.8.0
-google-api-core==1.30.0
+google-api-core==2.7.1
 google-auth==1.31.0
 google-auth-oauthlib==0.4.4
 google-cloud-bigquery==3.0.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -74,7 +74,7 @@ py==1.10.0
 pyarrow==4.0.1
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
-pybigquery==0.7.0
+sqlalchemy-bigquery==1.4.3
 pycparser==2.20
 pydata-google-auth==1.2.0
 Pygments==2.9.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,7 +22,7 @@ gcsfs==0.8.0
 google-api-core==1.30.0
 google-auth==1.31.0
 google-auth-oauthlib==0.4.4
-google-cloud-bigquery==2.16.1
+google-cloud-bigquery==3.0.1
 google-cloud-bigquery-storage==2.8.0
 google-cloud-core==1.7.0
 google-crc32c==1.1.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,7 +28,7 @@ google-cloud-core==1.7.0
 google-crc32c==1.1.2
 google-resumable-media==1.3.0
 googleapis-common-protos==1.53.0
-grpcio==1.38.0
+grpcio==1.44.0
 identify==2.2.10
 idna==2.10
 iniconfig==1.1.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,7 +24,7 @@ google-auth==1.31.0
 google-auth-oauthlib==0.4.4
 google-cloud-bigquery==3.0.1
 google-cloud-bigquery-storage==2.8.0
-google-cloud-core==1.7.0
+google-cloud-core==2.2.3
 google-crc32c==1.1.2
 google-resumable-media==1.3.0
 googleapis-common-protos==1.53.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ gcsfs==0.8.0
 google-api-core==2.7.1
 google-auth==1.31.0
 google-auth-oauthlib==0.4.4
-google-cloud-bigquery==3.0.1
+google-cloud-bigquery==2.25.2
 google-cloud-core==2.2.3
 google-crc32c==1.1.2
 google-resumable-media==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ ptyprocess==0.7.0
 py==1.10.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
-pybigquery==0.7.0
+sqlalchemy-bigquery==1.4.3
 pycparser==2.20
 pydata-google-auth==1.2.0
 Pygments==2.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ google-api-core==2.7.1
 google-auth==1.31.0
 google-auth-oauthlib==0.4.4
 google-cloud-bigquery==3.0.1
-google-cloud-core==1.7.0
+google-cloud-core==2.2.3
 google-crc32c==1.1.2
 google-resumable-media==1.3.0
 googleapis-common-protos==1.53.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ gcsfs==0.8.0
 google-api-core==1.30.0
 google-auth==1.31.0
 google-auth-oauthlib==0.4.4
-google-cloud-bigquery==2.16.1
+google-cloud-bigquery==3.0.1
 google-cloud-core==1.7.0
 google-crc32c==1.1.2
 google-resumable-media==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ filelock==3.0.12
 fsspec==2021.6.0
 future==0.18.2
 gcsfs==0.8.0
-google-api-core==1.30.0
+google-api-core==2.7.1
 google-auth==1.31.0
 google-auth-oauthlib==0.4.4
 google-cloud-bigquery==3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ google-cloud-core==1.7.0
 google-crc32c==1.1.2
 google-resumable-media==1.3.0
 googleapis-common-protos==1.53.0
-grpcio==1.38.0
+grpcio==1.44.0
 gtfs-realtime-bindings==0.0.7
 identify==2.2.10
 idna==2.10

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         "gcsfs",
         "pandas",
         "pandas-gbq",
-        "pybigquery",
+        "sqlalchemy-bigquery",
         "google-cloud-bigquery",
         "gtfs-realtime-bindings",
     ],


### PR DESCRIPTION
This PR addresses dependency issues in calitp-py

Files Edited:
`setup.py`
* substituted `sqlalchemy-bigquery` for `pybigquery` which was causing dependency issues
* Flagged in this [GH issue comment](https://github.com/machow/siuba/issues/407#issuecomment-1082460991), noticed as a dependency issue in `siuba`
*addresses the first need of [issue #1313 in data-infra](https://github.com/cal-itp/data-infra/issues/1313) from @tiffanychu90, from here the Jupyter image needs to be updated

`__init__.py`
* bumped up version number for new release

Files changed by `black` formatter:
* `__main__.py`
* `config.py`
* `tests/test_tables.py`