### PR TITLE
add github cli and git lfs to hub image, and update gcloud to good version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,18 +4,23 @@ LABEL org.opencontainers.image.source https://github.com/cal-itp/calitp-py
 
 USER root
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+# GitHub CLI https://github.com/cli/cli/blob/trunk/docs/install_linux.md
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
 RUN apt update \
     && apt install keychain \
-    && apt install -y nodejs
+    && apt install -y nodejs \
+    && apt install git-lfs \
+    && apt install gh
 USER $NB_UID
+RUN npm install -g --unsafe-perm=true --allow-root netlify-cli
 
-RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-361.0.0-linux-x86_64.tar.gz \
-    && tar -zxvf google-cloud-sdk-361.0.0-linux-x86_64.tar.gz \
+# gcloud CLI https://cloud.google.com/sdk/docs/install#deb
+RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-377.0.0-linux-x86_64.tar.gz \
+    && tar -zxvf google-cloud-sdk-377.0.0-linux-x86_64.tar.gz \
     && ./google-cloud-sdk/install.sh
 
 ADD _jupyterhub/requirements.txt /app/requirements.txt
-
-RUN npm install -g --unsafe-perm=true --allow-root netlify-cli
 
 RUN pip install -r /app/requirements.txt
 


### PR DESCRIPTION
First step towards completing https://github.com/cal-itp/data-analyses/issues/275

I've tested this builds locally and `gh` and `git lfs` show output.

This PR also updates gcloud to version 377 because the upstream data science book now has python 3.10, which removes some deprecated functionality that was utilized in older versions of gcloud https://issuetracker.google.com/issues/202172882