### PR TITLE
make geopandas happy with python 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,7 @@ RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
 RUN apt update \
-    && apt install keychain \
-    && apt install -y nodejs \
-    && apt install git-lfs \
-    && apt install gh
+    && apt install -y keychain nodejs git-lfs gh libspatialindex-dev
 USER $NB_UID
 RUN npm install -g --unsafe-perm=true --allow-root netlify-cli
 


### PR DESCRIPTION
The upstream jupyter notebook image updated to Python 3.10 and we haven't been fixing to a specific version. Consequently, deploying a new version of our Hub image (https://github.com/cal-itp/calitp-py/pull/61) caused 3.10 to be installed, which conflicts with geopandas as discovered by @amandaha8. Some GitHub issues point at libspatialindex (https://github.com/Toblerity/rtree/issues/64) so we just need to install it via apt.