### PR TITLE
docker: bumped up voila version in jupyter image to 0.3.6 to fix 404 error

### DIFF
--- a/_jupyterhub/requirements.txt
+++ b/_jupyterhub/requirements.txt
@@ -8,7 +8,7 @@ ipyleaflet==0.15.0
 jupytext==1.13.5
 jupyterlab-code-formatter==1.4.10
 siuba==1.0.0a2
-voila==0.3.0
+voila==0.3.6
 plotnine==0.8.0
 plotly==5.5.0
 folium==0.12.1.post1


### PR DESCRIPTION
Bumping up version of voila in the Jupyter docker image to fix 404 error experienced by Natalie in the analytics team 

Tested locally