### PR TITLE
Adjustments to support new parsing and validation Airflow jobs

### DIFF
--- a/calitp/storage.py
+++ b/calitp/storage.py
@@ -535,7 +535,7 @@ class GTFSRTFeedExtract(GTFSFeedExtractInfo):
         Used for RT validation; it's faster to download and validate many files at once, and we need to identify
         them on disk.
         """
-        return str(self.path.name) + self.tick.strftime("__%Y-%m-%dT%H:%M:%SZ")
+        return str(self.filename) + self.ts.strftime("__%Y-%m-%dT%H:%M:%SZ")
 
     @property
     def schedule_extract(self) -> GTFSFeedExtractInfo:
@@ -543,7 +543,7 @@ class GTFSRTFeedExtract(GTFSFeedExtractInfo):
             GTFSFeedExtractInfo.bucket_table(),
             partitions={name: get_type_hints(self).get(name, str) for name in self.partition_names},
         )
-        return
+        return parse_obj_as(GTFSFeedExtractInfo, json.loads(get_fs().getxattr(file.name, PARTITIONED_ARTIFACT_METADATA_KEY)))
 
 
 def download_feed(

--- a/calitp/storage.py
+++ b/calitp/storage.py
@@ -290,8 +290,8 @@ class PartitionedGCSArtifact(BaseModel, abc.ABC):
 
     @root_validator(allow_reuse=True)
     def check_partitions(cls, values):
-        # TODO: this isn't great but feed extract partitions do depend on config
-        if cls == GTFSFeedExtractInfo:
+        # TODO: this isn't great but some partition_names are properties
+        if isinstance(cls.partition_names, property):
             return values
         cls_properties = [name for name in dir(cls) if isinstance(getattr(cls, name), property)]
         missing = [name for name in cls.partition_names if name not in values and name not in cls_properties]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "calitp"
-version = "2022.8.17-alpha.1"
+version = "2022.8.17"
 description = "Shared code for the Cal-ITP data codebases"
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 license = "GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "calitp"
-version = "2022.8.17-alpha.0"
+version = "2022.8.17-alpha.1"
 description = "Shared code for the Cal-ITP data codebases"
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 license = "GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "calitp"
-version = "2022.8.15-alpha.0"
+version = "2022.8.17-alpha.0"
 description = "Shared code for the Cal-ITP data codebases"
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 license = "GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "calitp"
-version = "2022.8.12-alpha.2"
+version = "2022.8.15-alpha.0"
 description = "Shared code for the Cal-ITP data codebases"
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 license = "GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007"


### PR DESCRIPTION
Handle `@property` partition names and combine GTFS feed extract types.
Use a storage client directly for `fetch_all_in_partition` as it's substantially faster than gcsfs.