### PR TITLE
Simplify extract types to support RT v2 pipeline

### DIFF
--- a/calitp/storage.py
+++ b/calitp/storage.py
@@ -573,6 +573,7 @@ class GTFSRTFeedExtract(GTFSFeedExtract):
         if self.config.data == GTFSFeedType.schedule:
             raise TypeError("cannot call schedule_extract on a schedule extract")
 
+        # TODO: this does not work if we didn't download a schedule zip for that day
         file = get_latest_file(
             GTFSScheduleFeedExtract.bucket,
             GTFSScheduleFeedExtract.table,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "calitp"
-version = "2022.8.18.2a0"
+version = "2022.8.19a0"
 description = "Shared code for the Cal-ITP data codebases"
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 license = "GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "calitp"
-version = "2022.8.18.1"
+version = "2022.8.18.2"
 description = "Shared code for the Cal-ITP data codebases"
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 license = "GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "calitp"
-version = "2022.8.19a0"
+version = "2022.8.23"
 description = "Shared code for the Cal-ITP data codebases"
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 license = "GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "calitp"
-version = "2022.8.18.2"
+version = "2022.8.18.2a0"
 description = "Shared code for the Cal-ITP data codebases"
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 license = "GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -36,16 +36,19 @@ def test_get_fs_pipe(tmp_name):
 
 def test_airtable_gtfs_data_record_handles_weird_inputs() -> None:
     AirtableGTFSDataRecord(
+        id="abc",
         name="some valid name",
         data=None,
     )
     AirtableGTFSDataRecord(
+        id="abc",
         name="some valid name",
         data="",
     )
 
     with pytest.raises(ValidationError):
         AirtableGTFSDataRecord(
+            id="abc",
             name="some valid name",
             data="invalid string",
         )


### PR DESCRIPTION
This PR has been published as version 2022.8.23.

The primary change in this PR is splitting up the GTFS extract types. In general I'm trying to move to simpler Pydantic types and use functions to implement additional behavior as necessary.