### PR TITLE
Stop using removeprefix

### DIFF
--- a/calitp/storage.py
+++ b/calitp/storage.py
@@ -373,7 +373,9 @@ def fetch_all_in_partition(
     if verbose:
         print(f"listing all files in {bucket}/{prefix}")
     client = storage.Client()
-    files = client.list_blobs(bucket.removeprefix("gs://"), prefix=prefix, delimiter=None)
+    # once Airflow is upgraded to Python 3.9, can use:
+    # files = client.list_blobs(bucket.removeprefix("gs://"), prefix=prefix, delimiter=None)
+    files = client.list_blobs(re.sub(r"^gs://","",bucket), prefix=prefix, delimiter=None)
     return [parse_obj_as(cls, json.loads(file.metadata[PARTITIONED_ARTIFACT_METADATA_KEY])) for file in files]
 
 

--- a/calitp/storage.py
+++ b/calitp/storage.py
@@ -375,7 +375,7 @@ def fetch_all_in_partition(
     client = storage.Client()
     # once Airflow is upgraded to Python 3.9, can use:
     # files = client.list_blobs(bucket.removeprefix("gs://"), prefix=prefix, delimiter=None)
-    files = client.list_blobs(re.sub(r"^gs://","",bucket), prefix=prefix, delimiter=None)
+    files = client.list_blobs(re.sub(r"^gs://", "", bucket), prefix=prefix, delimiter=None)
     return [parse_obj_as(cls, json.loads(file.metadata[PARTITIONED_ARTIFACT_METADATA_KEY])) for file in files]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "calitp"
-version = "2022.8.25a0"
+version = "2022.8.25"
 description = "Shared code for the Cal-ITP data codebases"
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 license = "GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "calitp"
-version = "2022.8.23"
+version = "2022.8.25a0"
 description = "Shared code for the Cal-ITP data codebases"
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 license = "GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007"


### PR DESCRIPTION
# Description

This PR stops using `.removeprefix` because Cal-ITP Airflow is not on Python 3.9 yet (specifically, to unblock https://github.com/cal-itp/data-infra/pull/1696). 

This has been published as a pre-release: https://pypi.org/project/calitp/2022.8.25a0/. When PR is approved, I will bump to normal release & merge, to be used in https://github.com/cal-itp/data-infra/pull/1696 as a full release.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] agencies.yml

## How has this been tested?
I have tested that I can run the new DAG task in https://github.com/cal-itp/data-infra/pull/1696 with this change and it works

## Screenshots

<details>
<summary>Airflow output from successful run of new DAG task in #data-infra</summary>

```
listing all files in gs://test-calitp-gtfs-schedule-raw/schedule/dt=1901-01-01/
Identified 4 records for 1901-01-01
Processing schedule/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T12:43:06.265686+00:00/valid_dir.zip
Found files: ['dir/fare_attributes.txt', 'dir/agency.txt', 'dir/fare_rules.txt', 'dir/stop_times.txt', 'dir/shapes.txt', 'dir/trips.txt', 'dir/feed_info.txt', 'dir/stops.txt', 'dir/calendar.txt', 'dir/routes.txt'] and directories: ['dir/']
Valid zip gs://test-calitp-gtfs-schedule-raw/schedule/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T12:43:06.265686+00:00/valid_dir.zip: One toplevel directory found
[2022-08-25 14:22:58,346] {storage.py:320} INFO - saving 112 Bytes to gs://test-calitp-gtfs-schedule-unzipped/fare_attributes.txt/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T12:43:06.265686+00:00/fare_attributes.txt
[2022-08-25 14:22:58,706] {storage.py:320} INFO - saving 236 Bytes to gs://test-calitp-gtfs-schedule-unzipped/agency.txt/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T12:43:06.265686+00:00/agency.txt
[2022-08-25 14:22:59,062] {storage.py:320} INFO - saving 75 Bytes to gs://test-calitp-gtfs-schedule-unzipped/fare_rules.txt/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T12:43:06.265686+00:00/fare_rules.txt
[2022-08-25 14:22:59,428] {storage.py:320} INFO - saving 2.0 MB to gs://test-calitp-gtfs-schedule-unzipped/stop_times.txt/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T12:43:06.265686+00:00/stop_times.txt
[2022-08-25 14:23:00,467] {storage.py:320} INFO - saving 5.4 MB to gs://test-calitp-gtfs-schedule-unzipped/shapes.txt/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T12:43:06.265686+00:00/shapes.txt
[2022-08-25 14:23:02,387] {storage.py:320} INFO - saving 77.8 kB to gs://test-calitp-gtfs-schedule-unzipped/trips.txt/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T12:43:06.265686+00:00/trips.txt
[2022-08-25 14:23:03,105] {storage.py:320} INFO - saving 240 Bytes to gs://test-calitp-gtfs-schedule-unzipped/feed_info.txt/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T12:43:06.265686+00:00/feed_info.txt
[2022-08-25 14:23:03,726] {storage.py:320} INFO - saving 40.3 kB to gs://test-calitp-gtfs-schedule-unzipped/stops.txt/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T12:43:06.265686+00:00/stops.txt
[2022-08-25 14:23:04,100] {storage.py:320} INFO - saving 467 Bytes to gs://test-calitp-gtfs-schedule-unzipped/calendar.txt/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T12:43:06.265686+00:00/calendar.txt
[2022-08-25 14:23:04,467] {storage.py:320} INFO - saving 1.3 kB to gs://test-calitp-gtfs-schedule-unzipped/routes.txt/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T12:43:06.265686+00:00/routes.txt
Processing success: True
Processing schedule/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T13:43:06.265686+00:00/invalid_dir_toplevel.zip
Found files: ['dir/fare_attributes.txt', 'dir/agency.txt', 'dir/fare_rules.txt', 'dir/stop_times.txt', 'dir/shapes.txt', 'dir/trips.txt', 'dir/feed_info.txt', 'dir/stops.txt', 'dir/calendar.txt', 'dir/routes.txt', 'routes.txt', 'shapes.txt', 'stop_times.txt', 'stops.txt', 'trips.txt'] and directories: ['dir/']
Invalid zip gs://test-calitp-gtfs-schedule-raw/schedule/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T13:43:06.265686+00:00/invalid_dir_toplevel.zip: Mix of directories and files found
Processing success: False
Processing schedule/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T14:43:06.265686+00:00/invalid_dir_nested.zip
Found files: ['dir/second_dir/fare_attributes.txt', 'dir/second_dir/agency.txt', 'dir/second_dir/fare_rules.txt', 'dir/second_dir/stop_times.txt', 'dir/second_dir/shapes.txt', 'dir/second_dir/trips.txt', 'dir/second_dir/feed_info.txt', 'dir/second_dir/stops.txt', 'dir/second_dir/calendar.txt', 'dir/second_dir/routes.txt'] and directories: ['dir/', 'dir/second_dir/']
Invalid zip gs://test-calitp-gtfs-schedule-raw/schedule/dt=1901-01-01/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=1901-01-01T14:43:06.265686+00:00/invalid_dir_nested.zip: Multiple directories found
Processing success: False
Processing schedule/dt=2022-08-17/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=2022-08-17T17:43:06.265686+00:00/google_transit.zip
Found files: ['agency.txt', 'shapes.txt', 'trips.txt', 'stop_times.txt', 'stops.txt', 'routes.txt', 'calendar.txt', 'feed_info.txt', 'fare_attributes.txt', 'fare_rules.txt'] and directories: []
Valid zip gs://test-calitp-gtfs-schedule-raw/schedule/dt=2022-08-17/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=2022-08-17T17:43:06.265686+00:00/google_transit.zip
[2022-08-25 14:23:08,025] {storage.py:320} INFO - saving 236 Bytes to gs://test-calitp-gtfs-schedule-unzipped/agency.txt/dt=2022-08-17/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=2022-08-17T17:43:06.265686+00:00/agency.txt
[2022-08-25 14:23:08,558] {storage.py:320} INFO - saving 5.4 MB to gs://test-calitp-gtfs-schedule-unzipped/shapes.txt/dt=2022-08-17/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=2022-08-17T17:43:06.265686+00:00/shapes.txt
[2022-08-25 14:23:10,598] {storage.py:320} INFO - saving 77.8 kB to gs://test-calitp-gtfs-schedule-unzipped/trips.txt/dt=2022-08-17/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=2022-08-17T17:43:06.265686+00:00/trips.txt
[2022-08-25 14:23:11,236] {storage.py:320} INFO - saving 2.0 MB to gs://test-calitp-gtfs-schedule-unzipped/stop_times.txt/dt=2022-08-17/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=2022-08-17T17:43:06.265686+00:00/stop_times.txt
[2022-08-25 14:23:12,273] {storage.py:320} INFO - saving 40.3 kB to gs://test-calitp-gtfs-schedule-unzipped/stops.txt/dt=2022-08-17/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=2022-08-17T17:43:06.265686+00:00/stops.txt
[2022-08-25 14:23:12,640] {storage.py:320} INFO - saving 1.3 kB to gs://test-calitp-gtfs-schedule-unzipped/routes.txt/dt=2022-08-17/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=2022-08-17T17:43:06.265686+00:00/routes.txt
[2022-08-25 14:23:12,995] {storage.py:320} INFO - saving 467 Bytes to gs://test-calitp-gtfs-schedule-unzipped/calendar.txt/dt=2022-08-17/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=2022-08-17T17:43:06.265686+00:00/calendar.txt
[2022-08-25 14:23:13,345] {storage.py:320} INFO - saving 240 Bytes to gs://test-calitp-gtfs-schedule-unzipped/feed_info.txt/dt=2022-08-17/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=2022-08-17T17:43:06.265686+00:00/feed_info.txt
[2022-08-25 14:23:13,703] {storage.py:320} INFO - saving 112 Bytes to gs://test-calitp-gtfs-schedule-unzipped/fare_attributes.txt/dt=2022-08-17/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=2022-08-17T17:43:06.265686+00:00/fare_attributes.txt
[2022-08-25 14:23:14,051] {storage.py:320} INFO - saving 75 Bytes to gs://test-calitp-gtfs-schedule-unzipped/fare_rules.txt/dt=2022-08-17/base64_url=aHR0cDovL21hcmludHJhbnNpdC5vcmcvZGF0YS9nb29nbGVfdHJhbnNpdC56aXA=/ts=2022-08-17T17:43:06.265686+00:00/fare_rules.txt
Processing success: True
Saving results at gs://test-calitp-gtfs-schedule-unzipped/unzipping_results/dt=1901-01-01/results.jsonl
[2022-08-25 14:23:14,443] {storage.py:320} INFO - saving 6.3 kB to gs://test-calitp-gtfs-schedule-unzipped/unzipping_results/dt=1901-01-01/results.jsonl
[2022-08-25 14:23:14,805] {python.py:151} INFO - Done. Returned value was: None
[2022-08-25 14:23:14,814] {taskinstance.py:1212} INFO - Marking task as SUCCESS. dag_id=unzip_and_validate_gtfs_schedule, task_id=unzip_gtfs_schedule, execution_date=19010101T000000, start_date=20220824T222338, end_date=20220825T142314
```

</details>
