### PR TITLE
just return the secrets and let the caller decide what to do

### DIFF
--- a/calitp/auth.py
+++ b/calitp/auth.py
@@ -1,5 +1,5 @@
 import os
-from typing import Sequence
+from typing import Mapping, Sequence
 
 import google_crc32c
 from google.cloud import secretmanager
@@ -8,27 +8,26 @@ AUTH_KEYS_ENV_VAR = "CALITP_AUTH_KEYS"
 DEFAULT_AUTH_KEYS = tuple(os.environ[AUTH_KEYS_ENV_VAR].split(",")) if AUTH_KEYS_ENV_VAR in os.environ else tuple()
 
 
-def load_secrets(keys: Sequence[str] = DEFAULT_AUTH_KEYS, secret_client=secretmanager.SecretManagerServiceClient()):
-    if not keys:
-        print("no secrets to load")
-        return
+def get_secrets(
+    keys: Sequence[str] = DEFAULT_AUTH_KEYS,
+    secret_client=secretmanager.SecretManagerServiceClient(),
+) -> Mapping[str, str]:
+    secrets = {}
 
     for key in keys:
-        if key in os.environ:
-            print(f"found {key} already in os.environ, skipping")
-        else:
-            print(f"fetching secret {key}")
-            name = f"projects/cal-itp-data-infra/secrets/{key}/versions/latest"
-            response = secret_client.access_secret_version(request={"name": name})
+        name = f"projects/cal-itp-data-infra/secrets/{key}/versions/latest"
+        response = secret_client.access_secret_version(request={"name": name})
 
-            crc32c = google_crc32c.Checksum()
-            crc32c.update(response.payload.data)
-            if response.payload.data_crc32c != int(crc32c.hexdigest(), 16):
-                raise ValueError(f"Data corruption detected for secret {name}.")
+        crc32c = google_crc32c.Checksum()
+        crc32c.update(response.payload.data)
+        if response.payload.data_crc32c != int(crc32c.hexdigest(), 16):
+            raise ValueError(f"Data corruption detected for secret {name}.")
 
-            os.environ[key] = response.payload.data.decode("UTF-8").strip()
+        secrets[key] = response.payload.data.decode("UTF-8").strip()
+
+    return secrets
 
 
 if __name__ == "__main__":
     print("loading secrets...")
-    load_secrets()
+    print(get_secrets().keys())

--- a/calitp/auth.py
+++ b/calitp/auth.py
@@ -1,11 +1,7 @@
-import os
 from typing import Mapping
 
 import google_crc32c
 from google.cloud import secretmanager
-
-AUTH_KEYS_ENV_VAR = "CALITP_AUTH_KEYS"
-DEFAULT_AUTH_KEYS = tuple(os.environ[AUTH_KEYS_ENV_VAR].split(",")) if AUTH_KEYS_ENV_VAR in os.environ else tuple()
 
 
 def get_secrets_with_label(

--- a/calitp/auth.py
+++ b/calitp/auth.py
@@ -22,7 +22,7 @@ def get_secret_by_name(
     return response.payload.data.decode("UTF-8").strip()
 
 
-def get_secrets_with_label(
+def get_secrets_by_label(
     label: str,
     client=secretmanager.SecretManagerServiceClient(),
 ) -> Mapping[str, str]:
@@ -51,4 +51,4 @@ def get_secrets_with_label(
 if __name__ == "__main__":
     print("loading secrets...")
     get_secret_by_name("BEAR_TRANSIT_KEY")
-    print(get_secrets_with_label("gtfs_rt").keys())
+    print(get_secrets_by_label("gtfs_rt").keys())

--- a/calitp/auth.py
+++ b/calitp/auth.py
@@ -1,5 +1,5 @@
 import os
-from typing import Mapping, Sequence
+from typing import Mapping
 
 import google_crc32c
 from google.cloud import secretmanager
@@ -8,26 +8,33 @@ AUTH_KEYS_ENV_VAR = "CALITP_AUTH_KEYS"
 DEFAULT_AUTH_KEYS = tuple(os.environ[AUTH_KEYS_ENV_VAR].split(",")) if AUTH_KEYS_ENV_VAR in os.environ else tuple()
 
 
-def get_secrets(
-    keys: Sequence[str] = DEFAULT_AUTH_KEYS,
-    secret_client=secretmanager.SecretManagerServiceClient(),
+def get_secrets_with_label(
+    label: str,
+    client=secretmanager.SecretManagerServiceClient(),
 ) -> Mapping[str, str]:
-    secrets = {}
+    project = "projects/cal-itp-data-infra"
 
-    for key in keys:
-        name = f"projects/cal-itp-data-infra/secrets/{key}/versions/latest"
-        response = secret_client.access_secret_version(request={"name": name})
+    filter_request = {
+        "parent": project,
+        "filter": f"labels.{label}:*",
+    }
+
+    secret_values = {}
+
+    for secret in client.list_secrets(request=filter_request):
+        version = f"{secret.name}/versions/latest"
+        response = client.access_secret_version(request={"name": version})
 
         crc32c = google_crc32c.Checksum()
         crc32c.update(response.payload.data)
         if response.payload.data_crc32c != int(crc32c.hexdigest(), 16):
-            raise ValueError(f"Data corruption detected for secret {name}.")
+            raise ValueError(f"Data corruption detected for secret {version}.")
 
-        secrets[key] = response.payload.data.decode("UTF-8").strip()
+        secret_values[secret.name.split("/")[-1]] = response.payload.data.decode("UTF-8").strip()
 
-    return secrets
+    return secret_values
 
 
 if __name__ == "__main__":
     print("loading secrets...")
-    print(get_secrets().keys())
+    print(get_secrets_with_label("gtfs_rt").keys())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "calitp"
-version = "2022.10.27a0"
+version = "2022.10.27a1"
 description = "Shared code for the Cal-ITP data codebases"
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 license = "GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "calitp"
-version = "2022.10.27a3"
+version = "2022.10.27"
 description = "Shared code for the Cal-ITP data codebases"
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 license = "GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "calitp"
-version = "2022.10.27a1"
+version = "2022.10.27a2"
 description = "Shared code for the Cal-ITP data codebases"
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 license = "GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "calitp"
-version = "2022.10.26.1"
+version = "2022.10.26.1a0"
 description = "Shared code for the Cal-ITP data codebases"
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 license = "GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "calitp"
-version = "2022.10.26.1a0"
+version = "2022.10.27a0"
 description = "Shared code for the Cal-ITP data codebases"
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 license = "GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "calitp"
-version = "2022.10.26"
+version = "2022.10.26.1"
 description = "Shared code for the Cal-ITP data codebases"
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 license = "GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "calitp"
-version = "2022.10.27a2"
+version = "2022.10.27a3"
 description = "Shared code for the Cal-ITP data codebases"
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 license = "GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007"


### PR DESCRIPTION
Make the secret loading easier to use; allow callers to either get a single secret by name or all secrets with a given label. Also, just return the secrets rather than setting on the environ, which is silly in retrospect. Just let the caller decide what to do.