### PR TITLE
add a couple fields for schedule backfill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 # Docs build folder
 docs-build
 

--- a/calitp/storage.py
+++ b/calitp/storage.py
@@ -546,6 +546,7 @@ class GTFSDownloadConfig(BaseModel, extra=Extra.forbid):
     schedule_url_for_validation: Optional[HttpUrl]
     auth_query_params: Dict[str, str] = {}
     auth_headers: Dict[str, str] = {}
+    computed: bool = False
 
     @validator("extracted_at", allow_reuse=True)
     def coerce_extracted_at(cls, v):
@@ -648,6 +649,7 @@ class GTFSScheduleFeedExtract(GTFSFeedExtract):
     table: ClassVar[str] = GTFSFeedType.schedule
     feed_type: ClassVar[str] = GTFSFeedType.schedule
     partition_names: ClassVar[List[str]] = ["dt", "ts", "base64_url"]
+    reconstructed: bool = False
 
     @validator("config", allow_reuse=True)
     def is_schedule_type(cls, v: GTFSDownloadConfig):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "calitp"
-version = "2022.12.8"
+version = "2023.1.3"
 description = "Shared code for the Cal-ITP data codebases"
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 license = "GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "calitp"
-version = "2022.12.1"
+version = "2022.12.8"
 description = "Shared code for the Cal-ITP data codebases"
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 license = "GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007"


### PR DESCRIPTION
Adds `computed` to `GTFSDownloadConfig` and `reconstructed` to `GTFSScheduleFeedExtract` to indicate backfilled objects.

Used in https://github.com/cal-itp/data-infra/pull/2033