### PR TITLE
use inspector for autotable and also add views

### DIFF
--- a/calitp/tables.py
+++ b/calitp/tables.py
@@ -1,4 +1,5 @@
 from siuba.sql import LazyTbl
+from sqlalchemy.engine import Inspector
 
 from .config import is_development
 from .sql import get_engine
@@ -45,7 +46,8 @@ class AutoTable:
             del self.__dict__[k]
 
         # initialize ----
-        self._table_names = tuple(self._engine.table_names())
+        insp = Inspector(self._engine)
+        self._table_names = tuple(insp.get_table_names()) + tuple(insp.get_view_names())
 
         mappings = {}
         for name in self._table_names:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "calitp"
-version = "2023.1.3"
+version = "2023.1.17"
 description = "Shared code for the Cal-ITP data codebases"
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 license = "GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007"


### PR DESCRIPTION
Some of our RT fact tables are materialized as views, which do not show up in calitp-py currently. This PR uses the new Inspector in sqlalchemy to get both tables and views from the engine for AutoTable.