### PR TITLE
Add request kwargs to download_feed

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,28 +1,31 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v4.4.0
     hooks:
-      - id: flake8
-        args: ["--ignore=E203,E501,W503"] # rely on black for these
-        types:
-          - python
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
         args: ["--unsafe"]
       - id: check-added-large-files
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8
+        args: ["--ignore=E203,E501,W503"] # line too long and line before binary operator (black is ok with these)
+        types:
+          - python
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.1.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/bandit
-    rev: 1.7.0
+    rev: 1.7.4
     hooks:
       - id: bandit
         args: ["-ll", "--skip=B108,B608,B701"]
         files: .py$
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         args: ["--profile", "black", "--filter-files"]

--- a/calitp/auth.py
+++ b/calitp/auth.py
@@ -9,7 +9,6 @@ def get_secret_by_name(
     name: str,
     client=secretmanager.SecretManagerServiceClient(),
 ) -> str:
-
     version = f"{project}/secrets/{name}/versions/latest"
     response = client.access_secret_version(version)
     return response.payload.data.decode("UTF-8").strip()
@@ -19,7 +18,6 @@ def get_secrets_by_label(
     label: str,
     client=secretmanager.SecretManagerServiceClient(),
 ) -> Mapping[str, str]:
-
     secret_values = {}
 
     # once we get on at least 2.0.0 of secret manager, we can filter server-side

--- a/calitp/storage.py
+++ b/calitp/storage.py
@@ -686,10 +686,11 @@ def download_feed(
     auth_dict: Mapping[str, str],
     ts: pendulum.DateTime,
     default_filename="feed",
+    **request_kwargs,
 ) -> Tuple[GTFSFeedExtract, bytes]:
     s = Session()
     r = s.prepare_request(config.build_request(auth_dict))
-    resp = s.send(r)
+    resp = s.send(r, **request_kwargs)
     resp.raise_for_status()
 
     disposition_header = resp.headers.get("content-disposition", resp.headers.get("Content-Disposition"))
@@ -728,7 +729,7 @@ if __name__ == "__main__":
     with fs.open(extract.path, "rb") as f:
         content = gzip.decompress(f.read())
     records = [GTFSDownloadConfig(**json.loads(row)) for row in content.decode().splitlines()]
-    download_feed(records[0], auth_dict={}, ts=pendulum.now())
+    download_feed(records[0], auth_dict={}, ts=pendulum.now(), timeout=1)
     print("downloaded a thing!")
     sys.exit(0)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "calitp"
-version = "2023.1.17"
+version = "2023.2.1"
 description = "Shared code for the Cal-ITP data codebases"
 authors = ["Andrew Vaccaro <atvaccaro@gmail.com>"]
 license = "GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007"


### PR DESCRIPTION
Necessary for https://github.com/cal-itp/data-infra/issues/2046

Adds `**request_kwargs` to `download_feed` to let callers pass arguments such as timeouts to the underlying call to `send()`.

I've already published 2023.2.1 to pypi.