### PR TITLE
Update README for analysis package to reflect new import string

### DIFF
--- a/calitp-data-analysis/README.md
+++ b/calitp-data-analysis/README.md
@@ -1,7 +1,7 @@
 # calitp-data-analysis
 
 Functionality for querying notebooks. The most important functionality is
-probably the `AutoTable` accessible via `from calitp.storage import tbls` which
+probably the `AutoTable` accessible via `from calitp_data_analysis.tables import tbls` which
 provides siubar access to the BigQuery warehouse data models (tables or views).
 `get_engine()` underlies most functions that interact with the warehouse but can
 also be used directly to interact with BigQuery.


### PR DESCRIPTION
This is a small change to the `calitp-data-analysis` package README, updating an import example that was missed when the packages were split into three.