### PR TITLE
Remove get_fs from calitp-data-infra package

### DIFF
--- a/calitp-data-infra/calitp_data_infra/storage.py
+++ b/calitp-data-infra/calitp_data_infra/storage.py
@@ -26,7 +26,7 @@ import backoff
 import gcsfs
 import humanize
 import pendulum
-from calitp_data.config import get_bucket, is_cloud, require_pipeline
+from calitp_data.config import get_bucket, require_pipeline
 from calitp_data.storage import get_fs
 from google.cloud import storage
 from google.cloud.storage import Blob

--- a/calitp-data-infra/calitp_data_infra/storage.py
+++ b/calitp-data-infra/calitp_data_infra/storage.py
@@ -27,6 +27,7 @@ import gcsfs
 import humanize
 import pendulum
 from calitp_data.config import get_bucket, is_cloud, require_pipeline
+from calitp_data.storage import get_fs
 from google.cloud import storage
 from google.cloud.storage import Blob
 from pydantic import (
@@ -45,13 +46,6 @@ from typing_extensions import Annotated, Literal
 
 JSONL_EXTENSION = ".jsonl"
 JSONL_GZIP_EXTENSION = f"{JSONL_EXTENSION}.gz"
-
-
-def get_fs(gcs_project="", **kwargs):
-    if is_cloud():
-        return gcsfs.GCSFileSystem(project=gcs_project, token="cloud", **kwargs)
-    else:
-        return gcsfs.GCSFileSystem(project=gcs_project, token="google_default", **kwargs)
 
 
 @require_pipeline("save_to_gcfs")

--- a/calitp-data-infra/pyproject.toml
+++ b/calitp-data-infra/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "calitp-data-infra"
-version = "2023.5.30.1"
+version = "2023.5.30"
 description = "Shared code for developing data pipelines that process Cal-ITP data."
 authors = ["Andrew Vaccaro <andrew.v@jarv.us>"]
 

--- a/calitp-data-infra/pyproject.toml
+++ b/calitp-data-infra/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "calitp-data-infra"
-version = "2023.2.16.1"
+version = "2023.5.30.1"
 description = "Shared code for developing data pipelines that process Cal-ITP data."
 authors = ["Andrew Vaccaro <andrew.v@jarv.us>"]
 


### PR DESCRIPTION
Addresses #104, removing the redundant get_fs and redirecting references to it so that they source from calitp-data instead of calitp-data-infra. Also updates the version number on the calitp-data-infra package.